### PR TITLE
Minor mamba-2 fixes

### DIFF
--- a/fla/models/mamba2/configuration_mamba2.py
+++ b/fla/models/mamba2/configuration_mamba2.py
@@ -39,7 +39,7 @@ class Mamba2Config(PretrainedConfig):
             `inputs_ids` passed when calling [`Mamba2Model`].
         hidden_size (`int`, *optional*, defaults to 2048):
             Dimensionality of the embeddings and hidden states.
-        state_size (`int`, *optional*, defaults to 16): shape of the state space latents.
+        state_size (`int`, *optional*, defaults to 64): shape of the state space latents.
         num_hidden_layers (`int`, *optional*, defaults to 48):
             Number of hidden layers in the model.
         layer_norm_epsilon (`float`, *optional*, defaults to 1e-05):
@@ -98,7 +98,7 @@ class Mamba2Config(PretrainedConfig):
         head_dim: int = 64,
         vocab_size: int = 32000,
         hidden_size: int = 2048,
-        state_size: int = 16,
+        state_size: int = 64,
         num_hidden_layers: int = 48,
         layer_norm_epsilon: float = 1e-5,
         pad_token_id: int = 0,

--- a/fla/models/mamba2/modeling_mamba2.py
+++ b/fla/models/mamba2/modeling_mamba2.py
@@ -51,57 +51,55 @@ is_fast_path_available = all(
 )
 
 
-def pad_by_size(x, pad_size):
+def pad_tensor_by_size(input_tensor: torch.Tensor, pad_size: int):
     """
     Padding x tensor with `pad_size` on the seq_len dim (dim=1)
 
     Assumes that we only have tensors of either size 4 or 3
     """
-    assert 2 < len(x.shape) < 5
+    pad_shape = (0, 0, 0, 0, 0, pad_size, 0, 0) if len(input_tensor.shape) == 4 else (0, 0, 0, pad_size, 0, 0)
 
-    pad_shape = (
-        (0, 0, 0, 0, 0, pad_size, 0, 0)
-        if len(x.shape) == 4
-        else (0, 0, 0, pad_size, 0, 0)
-    )
-
-    return torch.nn.functional.pad(x, pad_shape, mode="constant", value=0)
+    return torch.nn.functional.pad(input_tensor, pad_shape, mode="constant", value=0)
 
 
-def reshape_into_chunks(x, pad_size, chunk_size):
+def reshape_into_chunks(input_tensor, pad_size, chunk_size):
     """
-    Padding x tensor with `pad_size` on the seq_len dim (dim=1) and
+    Padding input_tensor with `pad_size` on the seq_len dim (dim=1) and
     simultaneously splitting it into chunk sequences.
 
     Assumes that we only have tensors of either size 4 or 3
     """
     # [bsz, seq_len, ...] -> [bsz, seq_len multiple of chunk_size, ...]
-    x = pad_by_size(x, pad_size)
+    input_tensor = pad_tensor_by_size(input_tensor, pad_size)
 
-    if len(x.shape) == 3:
-        # b (l c) h -> b l c h with c=chunk_size
+    if len(input_tensor.shape) == 3:
         # [bsz, seq_len multiple of chunk_size, num_heads] -> [bsz, -1, chunk_size, num_heads]
-        return x.reshape(x.shape[0], -1, chunk_size, x.shape[2])
+        return input_tensor.reshape(input_tensor.shape[0], -1, chunk_size, input_tensor.shape[2])
     else:
-        # b (l c) h p -> b l c h p with c=chunk_size
-        # [bsz, seq_len multiple of chunk_size, num_heads, head_dim or state_size] ->
-        # [bsz, -1, chunk_size, num_heads, head_dim or state_size]
-        return x.reshape(x.shape[0], -1, chunk_size, x.shape[2], x.shape[3])
+        # [bsz, seq_len multiple of chunk_size, num_heads, head_dim or state_size] -> [bsz, -1, chunk_size, num_heads, head_dim or state_size]
+        return input_tensor.reshape(
+            input_tensor.shape[0], -1, chunk_size, input_tensor.shape[2], input_tensor.shape[3]
+        )
 
 
-def segsum(x):
+def segment_sum(input_tensor):
     """
-    More stable segment sum calculation
+    More stable segment sum calculation. Uses cumulative sums and masking instead of direct subtractions.
     """
-    T = x.size(-1)
+    chunk_size = input_tensor.size(-1)
+    # 1. expand input tensor to have an additional dimension and repeat along that dimension
     # [..., chunk_size] -> [..., chunk_size, chunk_size]
-    x = x.unsqueeze(-1).expand(*x.size(), T)
-    mask = torch.tril(torch.ones(T, T, device=x.device, dtype=torch.bool), diagonal=-1)
-    x = x.masked_fill(~mask, 0)
-    x_segsum = torch.cumsum(x, dim=-2)
-    mask = torch.tril(torch.ones(T, T, device=x.device, dtype=torch.bool), diagonal=0)
-    x_segsum = x_segsum.masked_fill(~mask, -torch.inf)
-    return x_segsum
+    input_tensor = input_tensor[..., None].expand(*input_tensor.size(), chunk_size)
+    # 2. create a lower triangular mask with the diagonal set to 0 to 0 out elements above diag
+    mask = torch.tril(torch.ones(chunk_size, chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=-1)
+    input_tensor = input_tensor.masked_fill(~mask, 0)
+    # 3. compute actual cumsum
+    tensor_segsum = torch.cumsum(input_tensor, dim=-2)
+
+    # 4. apply mask to keep only the lower triangular part of the cumulative sum result (incl diagonal this time)
+    mask = torch.tril(torch.ones(chunk_size, chunk_size, device=input_tensor.device, dtype=torch.bool), diagonal=0)
+    tensor_segsum = tensor_segsum.masked_fill(~mask, -torch.inf)
+    return tensor_segsum
 
 
 class Mamba2Cache:
@@ -218,13 +216,11 @@ class Mamba2Mixer(nn.Module):
             padding=config.conv_kernel - 1,
         )
 
-        # projection of the input hidden states
+        # projection of the input hidden state
+        projection_size = self.intermediate_size + self.conv_dim + self.num_head
         self.in_proj = nn.Linear(
             self.hidden_size,
-            2 * self.intermediate_size
-            + 2 * self.n_groups * self.ssm_state_size
-            + self.num_heads,
-            bias=config.use_bias,
+            projection_size,
         )
         # selective projection used to make dt, B and C input dependant
 
@@ -241,9 +237,8 @@ class Mamba2Mixer(nn.Module):
             self.intermediate_size, eps=self.layer_norm_epsilon
         )
 
-        self.D_has_hdim = False
         self.D = nn.Parameter(
-            torch.ones(self.ssm_state_size if self.D_has_hdim else self.num_heads)
+            torch.ones(self.num_heads)
         )
         self.D._no_weight_decay = True
 
@@ -268,32 +263,21 @@ class Mamba2Mixer(nn.Module):
         cache_position: Optional[torch.LongTensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
     ):
-        seq_len = hidden_states.shape[1]
+        batch_size, seq_len, _ = hidden_states.shape
+        groups_time_state_size = self.n_groups * self.ssm_state_size
+        d_to_remove = 2 * self.intermediate_size + 2 * self.n_groups * self.ssm_state_size + self.num_heads
         # getting projected states from cache if it exists
         if cache_params is not None and cache_params.seqlen_offset > 0:
-            batch_size = hidden_states.shape[0]
-            zxbcdt = self.in_proj(hidden_states.squeeze(1))  # (B 2D)
+            in_projected_states = self.in_proj(hidden_states.squeeze(1))  # (B 2D)
             d_mlp = (
+            d_mlp = (in_projected_states.shape[-1] - d_to_remove) // 2
                 zxbcdt.shape[-1]
+            split_projection_dim = [d_mlp, d_mlp, self.intermediate_size, self.conv_dim, self.num_heads]
                 - 2 * self.intermediate_size
-                - 2 * self.n_groups * self.ssm_state_size
-                - self.num_heads
-            ) // 2
+            _, _, gate, hidden_states_B_C, dt = torch.split(in_projected_states, split_projection_dim, dim=-1)
 
-            z0, x0, gate, xBC, dt = torch.split(
-                zxbcdt,
-                [
-                    d_mlp,
-                    d_mlp,
-                    self.intermediate_size,
-                    self.intermediate_size + 2 * self.n_groups * self.ssm_state_size,
-                    self.num_heads,
-                ],
-                dim=-1,
-            )
-
-            xBC = causal_conv1d_update(
-                xBC,
+            hidden_states_B_C = causal_conv1d_update(
+                hidden_states_B_C,
                 cache_params.conv_states[self.layer_idx],
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
@@ -301,35 +285,24 @@ class Mamba2Mixer(nn.Module):
             )
 
             hidden_states, B, C = torch.split(
-                xBC,
+                hidden_states_B_C,
                 [
                     self.intermediate_size,
-                    self.n_groups * self.ssm_state_size,
-                    self.n_groups * self.ssm_state_size,
+                    groups_time_state_size,
+                    groups_time_state_size,
                 ],
                 dim=-1,
             )
             A = -torch.exp(self.A_log.float())  # (nheads,)
 
-            A = (
-                A.unsqueeze(1)
-                .unsqueeze(2)
-                .expand(-1, self.head_dim, self.ssm_state_size)
-                .to(dtype=torch.float32)
-            )
-            dt = dt.unsqueeze(2).expand(-1, -1, self.head_dim)
-            dt_bias = self.dt_bias.unsqueeze(1).expand(-1, self.head_dim)
-            D = self.D.unsqueeze(1).expand(
-                -1, self.head_dim
-            )  # repeat(self.D, "h -> h p", p=self.head_dim)
-            B = B.view(B.shape[0], self.n_groups, B.shape[1] // self.n_groups)
-            C = C.view(C.shape[0], self.n_groups, C.shape[1] // self.n_groups)
-            hidden_states_reshaped = hidden_states.view(
-                batch_size, self.num_heads, self.head_dim
-            )
-            if not self.rms_norm:
-                gate = gate.view(batch_size, self.intermediate_size, self.head_dim)
-                # gate = rearrange(gate, "b (h p) -> b h p", p=self.head_dim)
+            A = A[:, None, ...][:, :, None].expand(-1, self.head_dim, self.ssm_state_size).to(dtype=torch.float32)
+            dt = dt[:, :, None].expand(-1, -1, self.head_dim)
+            dt_bias = self.dt_bias[:, None, ...].expand(-1, self.head_dim)
+            D = self.D[:, None, ...].expand(-1, self.head_dim)
+            B = B.view(batch_size, self.n_groups, B.shape[1] // self.n_groups)
+            C = C.view(batch_size, self.n_groups, C.shape[1] // self.n_groups)
+            hidden_states_reshaped = hidden_states.view(batch_size, self.num_heads, self.head_dim)
+            
             hidden_states = selective_state_update(
                 cache_params.ssm_states[self.layer_idx],
                 hidden_states_reshaped,
@@ -338,23 +311,22 @@ class Mamba2Mixer(nn.Module):
                 B,
                 C,
                 D,
-                z=gate if not self.rms_norm else None,
+                z=None,
                 dt_bias=dt_bias,
                 dt_softplus=True,
             )
             hidden_states = hidden_states.view(
                 batch_size, self.num_heads * self.head_dim
             )
-            if self.rms_norm:
-                hidden_states = self.norm(hidden_states, o=gate)
-            if d_mlp > 0:
-                hidden_states = torch.cat(
-                    [torch.nn.functional.silu(z0) * x0, hidden_states], dim=-1
-                )
+            hidden_states = self.norm(hidden_states, o=gate)
 
-            out = self.out_proj(hidden_states).unsqueeze(1)
+            out = self.out_proj(hidden_states)[:, None, ...]
         # if no cache is found, calling the kernel
         else:
+            if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+                # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
+                dtype = hidden_states.dtype
+                hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
             # 1. Gated MLP's linear projection
             projected_states = self.in_proj(hidden_states)
             A = -torch.exp(
@@ -389,7 +361,7 @@ class Mamba2Mixer(nn.Module):
                 )
 
             else:
-                gate, xBC, time_step = torch.split(
+                gate, hidden_states_B_C, time_step = torch.split(
                     projected_states,
                     [self.intermediate_size, self.conv_dim, self.num_heads],
                     dim=-1,
@@ -408,22 +380,22 @@ class Mamba2Mixer(nn.Module):
                 time_step = nn.functional.softplus(time_step + self.dt_bias)
                 # 1D Convolution
                 if causal_conv1d_fn is None or self.activation not in ["silu", "swish"]:
-                    xBC = self.act(
-                        self.conv1d(xBC.transpose(1, 2)).transpose(1, 2)[:, :seq_len]
+                    hidden_states_B_C = self.act(
+                        self.conv1d(hidden_states_B_C.transpose(1, 2)).transpose(1, 2)[:, :seq_len]
                     )  # (B, L, self.d_inner + 2 * ngroups * d_state)
                 else:
-                    xBC = causal_conv1d_fn(
-                        x=xBC.transpose(1, 2),
+                    hidden_states_B_C = causal_conv1d_fn(
+                        x=hidden_states_B_C.transpose(1, 2),
                         weight=self.conv1d.weight.squeeze(1),
                         bias=self.conv1d.bias,
                         activation=self.activation,
                     ).transpose(1, 2)[:, :seq_len]
                 hidden_states, B, C = torch.split(
-                    xBC,
+                    hidden_states_B_C,
                     [
                         self.intermediate_size,
-                        self.n_groups * self.ssm_state_size,
-                        self.n_groups * self.ssm_state_size,
+                        groups_time_state_size,
+                        groups_time_state_size,
                     ],
                     dim=-1,
                 )
@@ -435,20 +407,19 @@ class Mamba2Mixer(nn.Module):
                 ):
                     # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
                     dtype = hidden_states.dtype
-                    hidden_states = (hidden_states * attention_mask.unsqueeze(2)).to(
-                        dtype
-                    )
+                    hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
+
                 scan_output, ssm_state = mamba_chunk_scan_combined(
                     hidden_states.view(
-                        hidden_states.shape[0],
-                        hidden_states.shape[1],
+                        batch_size,
+                        seq_len,
                         -1,
                         self.head_dim,
                     ),
                     time_step,
                     A,
-                    B.view(B.shape[0], B.shape[1], self.n_groups, -1),
-                    C.view(B.shape[0], C.shape[1], self.n_groups, -1),
+                    B.view(batch_size, seq_len, self.n_groups, -1),
+                    C.view(batch_size, seq_len, self.n_groups, -1),
                     chunk_size=self.chunk_size,
                     D=self.D,
                     z=None,
@@ -459,7 +430,7 @@ class Mamba2Mixer(nn.Module):
                 if ssm_state is not None and cache_params is not None:
                     cache_params.ssm_states[self.layer_idx].copy_(ssm_state)
                 scan_output = scan_output.view(
-                    scan_output.shape[0], scan_output.shape[1], -1
+                    batch_size, seq_len, -1
                 )
                 # Multiply "gate" branch and apply extra normalization layer
                 scan_output = self.norm(scan_output, o=gate)
@@ -480,15 +451,14 @@ class Mamba2Mixer(nn.Module):
         projected_states = self.in_proj(input_states.squeeze(1))
         d_mlp = (projected_states.shape[-1] - 2 * self.intermediate_size - 2
                  * self.n_groups * self.ssm_state_size - self.num_heads) // 2
-        # z0 and x0 are empty tensors
-        z0, x0, gate, hidden_states, dt = projected_states.split(
+        _, _, gate, hidden_states, dt = projected_states.split(
             [d_mlp, d_mlp, self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
         )
 
         # Convolution sequence transformation
         if cache_params is not None:
             ssm_state = cache_params.ssm_states[self.layer_idx].clone()
-            ssm_state = ssm_state.to(x0.device)
+            ssm_state = ssm_state.to(hidden_states.device)
             if cache_params.seqlen_offset > 0:
                 conv_state = cache_params.conv_states[self.layer_idx]  # [batch, intermediate_size, conv_kernel_size]
                 conv_state = torch.roll(conv_state, shifts=-1, dims=-1)
@@ -498,7 +468,7 @@ class Mamba2Mixer(nn.Module):
                 hidden_states = torch.sum(conv_state.to(projected_states.device) * self.conv1d.weight[:, 0, :], dim=-1)
                 if self.use_conv_bias:
                     hidden_states += self.conv1d.bias
-                hidden_states = self.act(hidden_states).to(dtype).unsqueeze(1)  # [batch, 1, intermediate_size] : decoding
+                hidden_states = self.act(hidden_states).to(dtype)[:, None, ...]  # [batch, 1, intermediate_size] : decoding
             else:
                 hidden_states = hidden_states.transpose(1, 2)
                 conv_state = nn.functional.pad(
@@ -508,6 +478,10 @@ class Mamba2Mixer(nn.Module):
                 cache_params.conv_states[self.layer_idx].copy_(conv_state)
                 hidden_states = self.act(self.conv1d(
                     hidden_states).transpose(1, 2))[:, :seq_len, :]  # [batch, intermediate_size, seq_len]
+                if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+                    dtype = hidden_states.dtype
+                    # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
+                    hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
         else:
             ssm_state = torch.zeros(
                 (batch_size, self.num_heads, self.head_dim, self.ssm_state_size),
@@ -521,32 +495,33 @@ class Mamba2Mixer(nn.Module):
             assert attention_mask.shape[-1] == 1
             # Note: there is no need to pad parameter matrices here, as there is just one new token
             # for batched generation
-            dt = dt.unsqueeze(1) if dt.ndim == 2 else dt[:, 0, :].unsqueeze(1)
-            dt = dt.transpose(1, 2).expand(dt.shape[0], dt.shape[-1], self.head_dim)
+            dt = dt[:, None, ...] if dt.ndim == 2 else dt[:, 0, :][:, None, ...]
+            dt = dt.transpose(1, 2).expand(batch_size, dt.shape[-1], self.head_dim)
             # [num_heads] -> [num_heads, head_dim]
-            dt_bias = self.dt_bias.unsqueeze(-1).expand(self.dt_bias.shape[0], self.head_dim)
+            dt_bias = self.dt_bias[..., None].expand(self.dt_bias.shape[0], self.head_dim)
 
             dt = torch.nn.functional.softplus(dt + dt_bias.to(dt.dtype))
             dt = torch.clamp(dt, self.time_step_min)  # , self.time_step_max)
-            A = A[..., None, None].expand(A.shape[0], self.head_dim,
+            A = A[..., None, None].expand(self.num_heads, self.head_dim,
                                           self.ssm_state_size).to(dtype=torch.float32)
             # [bsz, num_heads, head_dim, state_size]
-            dA = torch.exp(dt.unsqueeze(-1) * A)
+            dA = torch.exp(dt[..., None] * A)
 
             # Discretize B
             # [bsz, n_groups * state_size] -> [bsz, n_groups, 1, state_size] ->
             # -> [bsz, n_groups, group to head repetition factor, state_size] -> [bsz, num_heads, state_size]
-            B = B.reshape(B.shape[0], self.n_groups, -1).unsqueeze(-2)
-            B = B.expand(B.shape[0], B.shape[1], self.num_heads
+            B = B.reshape(batch_size, self.n_groups, -1)[..., None, :]
+            B = B.expand(batch_size, self.n_groups, self.num_heads
                          // self.n_groups, B.shape[-1]).contiguous()
-            B = B.reshape(B.shape[0], -1, B.shape[-1])
+
+            B = B.reshape(batch_size, -1, B.shape[-1])
             # [bsz, num_heads, head_dim, state_size]
-            dB = dt.unsqueeze(-1) * B.unsqueeze(-2)
+            dB = dt[..., None] * B[..., None, :]
 
             # Discretize x into dB
             # [bsz, intermediate_size] -> [bsz, num_heads, head_dim]
-            hidden_states = hidden_states.reshape(hidden_states.shape[0], -1, self.head_dim)
-            dBx = dB * hidden_states.unsqueeze(-1)
+            hidden_states = hidden_states.reshape(batch_size, -1, self.head_dim)
+            dBx = dB * hidden_states[..., None]
 
             # State calculation
             cache_params.ssm_states[self.layer_idx].copy_(
@@ -555,9 +530,10 @@ class Mamba2Mixer(nn.Module):
 
             # Subsequent output
             # [bsz, n_groups * state_size] -> [bsz, num_heads, state_size]
-            C = C.reshape(C.shape[0], self.n_groups, -1).unsqueeze(-2)
-            C = C.expand(C.shape[0], C.shape[1], self.num_heads // self.n_groups, C.shape[-1]).contiguous()
-            C = C.reshape(C.shape[0], -1, C.shape[-1])
+            C = C.reshape(batch_size, self.n_groups, -1)[..., None, :]
+            C = C.expand(batch_size, self.n_groups, self.num_heads
+                         // self.n_groups, C.shape[-1]).contiguous()
+            C = C.reshape(batch_size, -1, C.shape[-1])
             # [bsz, num_heads, head_dim]
 
             ssm_states = cache_params.ssm_states[self.layer_idx].to(C.dtype)  # Shape: [b, h, d, n]
@@ -569,16 +545,16 @@ class Mamba2Mixer(nn.Module):
 
             # D skip connection
             # [num_heads] -> [num_heads, head_dim]
-            D = self.D.unsqueeze(-1).expand(self.D.shape[0], self.head_dim)
+            D = self.D[..., None].expand(self.D.shape[0], self.head_dim)
             y = (y + hidden_states * D).to(y.dtype)
 
             # [bsz, num_heads, head_dim] -> [bsz, 1, intermediate_size]
-            y = y.reshape(y.shape[0], -1).unsqueeze(1)
+            y = y.reshape(batch_size, -1)[:, None, ...]
         else:
             # begin ssd naive implementation without einsums
             dt = nn.functional.softplus(dt + self.dt_bias)
             dt = torch.clamp(dt, self.time_step_min)  # , self.time_step_max)
-            hidden_states = hidden_states.reshape(hidden_states.shape[0], hidden_states.shape[1], -1, self.head_dim).float()
+            hidden_states = hidden_states.reshape(batch_size, seq_len, -1, self.head_dim).float()
             B = B.reshape(batch_size, seq_len, -1, self.ssm_state_size).float()
             C = C.reshape(batch_size, seq_len, -1, self.ssm_state_size).float()
             B = B.repeat(1, 1, self.num_heads // self.n_groups, 1)
@@ -586,14 +562,14 @@ class Mamba2Mixer(nn.Module):
             seq_len = hidden_states.shape[1]
             pad_size = self.chunk_size - (seq_len % self.chunk_size)
 
-            D_residual = self.D.unsqueeze(-1) * pad_by_size(hidden_states, pad_size)
+            D_residual = self.D[..., None] * pad_tensor_by_size(hidden_states, pad_size)
 
             # Discretize x and A
-            hidden_states = hidden_states * dt.unsqueeze(-1)
+            hidden_states = hidden_states * dt[..., None]
             A = A.to(hidden_states.dtype) * dt
 
             # Rearrange into blocks/chunks
-            hidden_states, A, B, C = (reshape_into_chunks(t, pad_size, self.chunk_size) for t in (hidden_states, A, B, C))
+            hidden_states, A, B, C = [reshape_into_chunks(t, pad_size, self.chunk_size) for t in (hidden_states, A, B, C)]
 
             # [bsz, -1, chunk_size, num_heads] -> [bsz, num_heads, -1, chunk_size]
             A = A.permute(0, 3, 1, 2)
@@ -601,7 +577,7 @@ class Mamba2Mixer(nn.Module):
 
             # 1. Compute the output for each intra-chunk (diagonal blocks)
             # This is the analog of a causal mask
-            L = torch.exp(segsum(A))
+            L = torch.exp(segment_sum(A))
 
             # First, contraction of C and B to get G (attention-weights like)
             G_intermediate = C[:, :, :, None, :, :] * B[:, :, None, :, :, :]  # shape: (b, c, l, s, h, n)
@@ -612,29 +588,23 @@ class Mamba2Mixer(nn.Module):
             M = M_intermediate.sum(dim=-1)
 
             # Step 3: Compute Y_diag (apply to values)
-            # Y_diag = ((M.unsqueeze(-1) * hidden_states.unsqueeze(1)).sum(dim=3))
-            # Y_diag_einsum = torch.einsum("bclsh,bcshp->bclhp", M, hidden_states)
-            # Y_diag_alt = (M.unsqueeze(-1) * hidden_states.unsqueeze(2)).sum(3)
-            # diff_ = ((Y_diag_alt - Y_diag_einsum) / (Y_diag_einsum + 1e-9)).min()
+            Y_diag = (M[..., None] * hidden_states[:, :, None]).sum(3)
 
-            # Y_diag_intermediate = M[..., None] * hidden_states[:, None, ...]
-            # Y_diag = Y_diag_intermediate.sum(dim=3)
-
-            Y_diag = (M.unsqueeze(-1) * hidden_states.unsqueeze(2)).sum(3)
 
             # (right term of low-rank factorization of off-diagonal blocks; B terms)
 
-            decay_states = torch.exp(A_cumsum[:, :, :, -1:] - A_cumsum)
+            decay_states = torch.exp((A_cumsum[:, :, :, -1:] - A_cumsum))
             B_decay_contraction = B * decay_states.permute(0, 2, 3, 1)[..., None]
             # permute back B * decay states
-            states = (B_decay_contraction.permute(0, 1, 3, 2, 4)[..., None]
+            states = (B_decay_contraction.permute(0, 1, 3, 2, 4)[..., None] 
                       * hidden_states.permute(0, 1, 3, 2, 4)[..., None, :]).sum(dim=3).permute(0, 1, 2, 4, 3)
+
             if cache_params is not None and cache_params.seqlen_offset > 0:
-                previous_states = cache_params.ssm_states[self.layer_idx].unsqueeze(1)
+                previous_states = cache_params.ssm_states[self.layer_idx][:, None, ...]
             else:
                 previous_states = torch.zeros_like(states[:, :1])
             states = torch.cat([previous_states, states], dim=1)
-            decay_chunk = torch.exp(segsum(nn.functional.pad(A_cumsum[:, :, :, -1], (1, 0))))
+            decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:, :, :, -1], (1, 0))))
 
             states_permuted = states.permute(0, 2, 1, 3, 4)
             result = (decay_chunk[..., None, None] * states_permuted[:, :, None, ...]).sum(dim=2)
@@ -652,7 +622,7 @@ class Mamba2Mixer(nn.Module):
 
             y = Y_diag + Y_off
             # [bsz, -1, self.chunk_size, num_heads, head_dim] -> [bsz, (padded) seq_len, num_heads, head_dim]
-            y = y.reshape(y.shape[0], -1, self.num_heads, self.head_dim)
+            y = y.reshape(batch_size, -1, self.num_heads, self.head_dim)
 
             y = y + D_residual
             # Cutting off padded chunks
@@ -660,7 +630,7 @@ class Mamba2Mixer(nn.Module):
                 y = y[:, :seq_len, :, :]
 
             # move reshape to naive method
-            y = y.reshape(y.shape[0], y.shape[1], -1)
+            y = y.reshape(batch_size, seq_len, -1)
             if ssm_state is not None and cache_params is not None:
                 cache_params.ssm_states[self.layer_idx].copy_(ssm_state)
 
@@ -694,7 +664,7 @@ class Mamba2Mixer(nn.Module):
             and attention_mask.shape[0] > 1
         ):
             # tune out hidden states for pad tokens, see https://github.com/state-spaces/mamba/issues/66
-            hidden_states = (hidden_states * attention_mask.unsqueeze(2)).to(dtype)
+            hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
 
         return self.torch_forward(
             hidden_states, cache_params, cache_position, attention_mask
@@ -899,9 +869,7 @@ class Mamba2Model(Mamba2PreTrainedModel):
             if use_cache is not None
             else (self.config.use_cache if not self.training else False)
         )
-        return_dict = (
-            return_dict if return_dict is not None else self.config.use_return_dict
-        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if (input_ids is None) ^ (inputs_embeds is not None):  # ^ is python for xor
             raise ValueError(
@@ -1003,25 +971,6 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel):
     def set_input_embeddings(self, new_embeddings):
         return self.backbone.set_input_embeddings(new_embeddings)
 
-    def _update_model_kwargs_for_generation(
-        self,
-        outputs: ModelOutput,
-        model_kwargs: Dict[str, Any],
-        num_new_tokens: int = 1,
-        **kwargs,
-    ) -> Dict[str, Any]:
-        model_kwargs["cache_params"] = outputs.get("cache_params", None)
-        if (
-            model_kwargs.get("use_cache", True)
-            and "cache_position" in model_kwargs
-            and model_kwargs["cache_position"] is not None
-        ):
-            model_kwargs["cache_position"] = (
-                model_kwargs["cache_position"][-1:] + num_new_tokens
-            )
-
-        return model_kwargs
-
     def prepare_inputs_for_generation(
         self,
         input_ids,
@@ -1032,6 +981,10 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel):
         attention_mask: Optional[torch.Tensor] = None,
         **kwargs,
     ):
+        if input_ids.shape[1] == 0:
+            past_len = inputs_embeds.shape[1]
+        else:
+            past_len = input_ids.shape[1]
         if use_cache:
             # `cache_position` should have been initialized in `generate`
             if cache_position is None:
@@ -1042,33 +995,33 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel):
                 )
             # how do we detect that we are in decoding without cache?
             if cache_position[0] > 0:
-                input_ids = input_ids[:, -1].unsqueeze(-1)
-                attention_mask = attention_mask[:, -1].unsqueeze(-1)
+                input_ids = input_ids[:, -1][..., None]
+                attention_mask = attention_mask[:, -1][..., None]
             else:
                 # we initialize the `cache_position` to full size of `conv_states` at prefill stage
                 # considering padding will be applied when input length is shorter, and truncation
                 # will be applied when it is longer, so it will be equivalent to always have it match
                 # the length of `cache_params.conv_states`, which is `config.conv_kernel`
                 cache_position = torch.arange(
-                    0, input_ids.shape[1], device=input_ids.device
+                    0, past_len, device=input_ids.device
                 )
                 # if the cache is not used, we also do have to extend the attention mask here
                 # TODO there is likely a cleverer way to do this
                 extended_mask = torch.ones(
                     attention_mask.size(0),
-                    input_ids.shape[1] - attention_mask.shape[1],
+                    past_len - attention_mask.shape[1],
                     device=attention_mask.device,
                 )
                 attention_mask = torch.cat([attention_mask, extended_mask], dim=1)
             cache_params = None
-            if attention_mask.shape[1] < input_ids.shape[1]:
+            if attention_mask.shape[1] < past_len:
                 # we have to update manually the attention mask if
                 # we are in decoding without cache
                 # and we don't have position_ids here
                 # TODO but we should be able to use cache_position though at a later time
                 extended_mask = torch.ones(
                     attention_mask.size(0),
-                    input_ids.shape[1] - attention_mask.shape[1],
+                    past_len - attention_mask.shape[1],
                     device=attention_mask.device,
                 )
                 attention_mask = torch.cat([attention_mask, extended_mask], dim=1)
@@ -1106,9 +1059,7 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel):
             `labels = input_ids` Indices are selected in `[-100, 0, ..., config.vocab_size]` All labels set to `-100`
             are ignored (masked), the loss is only computed for labels in `[0, ..., config.vocab_size]`
         """
-        return_dict = (
-            return_dict if return_dict is not None else self.config.use_return_dict
-        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         mamba2_outputs = self.backbone(
             input_ids,
@@ -1122,7 +1073,7 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel):
         )
         hidden_states = mamba2_outputs[0]
 
-        logits = self.lm_head(hidden_states)
+        logits = self.lm_head(hidden_states.to(self.lm_head.weight.dtype)).float()
 
         loss = None
         if labels is not None:
@@ -1137,7 +1088,7 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel):
 
         if not return_dict:
             output = (logits,) + mamba2_outputs[1:]
-            return (loss,) + output if loss is not None else output
+            return ((loss,) + output) if loss is not None else output
 
         return Mamba2CausalLMOutput(
             loss=loss,


### PR DESCRIPTION
Some minor mamba-2 fixes (previously there could be some issues with peft, now it should be fixed). And I also updated mamba-2 default state_size to 64 as set in https://github.com/state-spaces/mamba . Mamba-2 is a bit more optimized in terms of states so it's default state_size should be 64 or 128 instead of 16 like for mamba-1.

Training benchmark output:
```
Initializing mamba2 model from the config:
Mamba2Config {
  "bos_token_id": 1,
  "chunk_size": 256,
  "conv_kernel": 4,
  "eos_token_id": 2,
  "expand": 2,
  "fuse_cross_entropy": true,
  "head_dim": 64,
  "hidden_act": "silu",
  "hidden_size": 2048,
  "initializer_range": 0.1,
  "layer_norm_epsilon": 1e-05,
  "model_type": "mamba2",
  "n_groups": 8,
  "norm_before_gate": true,
  "num_heads": 64,
  "num_hidden_layers": 48,
  "pad_token_id": 0,
  "rescale_prenorm_residual": false,
  "residual_in_fp32": true,
  "rms_norm": true,
  "state_size": 16,
  "tie_word_embeddings": false,
  "time_step_floor": 0.0001,
  "time_step_limit": [
    0.0,
    Infinity
  ],
  "time_step_max": 0.1,
  "time_step_min": 0.001,
  "time_step_rank": 128,
  "transformers_version": "4.43.4",
  "use_bias": false,
  "use_cache": true,
  "use_conv_bias": true,
  "vocab_size": 32000
}

Mamba2ForCausalLM(
  (backbone): Mamba2Model(
    (embeddings): Embedding(32000, 2048)
    (layers): ModuleList(
      (0-47): 48 x Mamba2Block(
        (norm): RMSNorm(2048, eps=1e-05)
        (mixer): Mamba2Mixer(
          (act): SiLU()
          (conv1d): Conv1d(4352, 4352, kernel_size=(4,), stride=(1,), padding=(3,), groups=4352)
          (in_proj): Linear(in_features=2048, out_features=8512, bias=False)
          (norm): FusedRMSNormSwishGate(4096, eps=1e-05)
          (out_proj): Linear(in_features=4096, out_features=2048, bias=False)
        )
      )
    )
    (norm_f): RMSNorm(2048, eps=1e-05)
  )
  (lm_head): Linear(in_features=2048, out_features=32000, bias=False)
)
Number of parameters in total: 1371839488 (1.28GiB)
Allocated memory after initialization: 2.56GiB
Max memory allocated: 37.25GiB: 100%|████████████████████████████████████████████████████████████████████████████████| 16/16 [00:43<00:00,  2.69s/it]
Thoughput:   19337.15 tokens/s: 100%|████████████████████████████████████████████████████████████████████████████████| 32/32 [00:27<00:00,  1.18it/s]```