### PR TITLE
[RWKV6] fix backward if h0 not passed

### DIFF
--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -750,7 +750,9 @@ class ChunkRWKV6Function(torch.autograd.Function):
             B=B, H=H, T=T, K=K, V=V, BT=BT, BK=BK, BV=BV, NT=NT,
             scale=scale
         )
-        dh, dh0 = dh.to(q), dh0.to(q)
+        dh = dh.to(q)
+        if initial_state is not None:
+            dh0 = dh0.to(q)
         dq = torch.empty_like(q, dtype=torch.float)
         dk = torch.empty_like(k, dtype=torch.float)
         dv = v.new_empty(NK, *v.shape)


### PR DESCRIPTION
Currently, if `initial_state` is not passed as 0s, it breaks: 

```python
/fla/ops/rwkv6/chunk.py", line 753, in backward
    dh, dh0 = dh.to(q), dh0.to(q)
AttributeError: 'NoneType' object has no attribute 'to'
```

Fix it by only doing tensor ops if the `initial_state` is passed