### PR TITLE
Update amp custom_fwd, custom_bwd usage for torch 2.4.0 compatibility

### DIFF
--- a/fla/ops/abc/recurrent_fuse.py
+++ b/fla/ops/abc/recurrent_fuse.py
@@ -7,9 +7,8 @@ from typing import Optional, Tuple
 import torch
 import triton
 import triton.language as tl
-from torch.cuda.amp import custom_bwd, custom_fwd
 
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 
 @triton.jit
@@ -284,7 +283,7 @@ class FusedRecurrentGatedABCFunction(torch.autograd.Function):
     
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(
         ctx,
         q: torch.Tensor,
@@ -374,7 +373,7 @@ class FusedRecurrentGatedABCFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do, dht=None):
         q, k, v, s, g, qv, hk0, hv0, ok = ctx.saved_tensors
         B, H, T, K, V, M = *q.shape, v.shape[-1], s.shape[-1]

--- a/fla/ops/based/chunk_fuse.py
+++ b/fla/ops/based/chunk_fuse.py
@@ -5,9 +5,8 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
-from torch.cuda.amp import custom_bwd, custom_fwd
 
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 # on-the-fly computation without materializing hidden statets into HBMs
 
@@ -305,7 +304,7 @@ class FusedChunkBasedFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, q, k, v, scale=1):
         B, H, T, K, V = *k.shape, v.shape[-1]
 
@@ -338,7 +337,7 @@ class FusedChunkBasedFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do, dz):
         q, k, v = ctx.saved_tensors
         B, H, T, K, V = *k.shape, v.shape[-1]

--- a/fla/ops/based/parallel.py
+++ b/fla/ops/based/parallel.py
@@ -6,9 +6,8 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
-from torch.cuda.amp import custom_bwd, custom_fwd
 
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 # Based: An Educational and Effective Sequence Mixer
 # https://hazyresearch.stanford.edu/blog/2023-12-11-zoology2-based
@@ -314,7 +313,7 @@ class ParallelBasedFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, q, k, v, scale):
         BTL, BTS = 128, 32
         assert BTL % BTS == 0
@@ -349,7 +348,7 @@ class ParallelBasedFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do, dz):
         q, k, v = ctx.saved_tensors
         scale = ctx.scale

--- a/fla/ops/delta_rule/chunk_fuse.py
+++ b/fla/ops/delta_rule/chunk_fuse.py
@@ -5,10 +5,9 @@ from typing import Tuple
 import torch
 import triton
 import triton.language as tl
-from torch.cuda.amp import custom_bwd, custom_fwd
 
 from fla.ops.delta_rule.utils import bwd_prepare_wy_repr, fwd_prepare_wy_repr
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 
 # on-the-fly computation without materializing hidden statets into HBMs
@@ -327,7 +326,7 @@ class FusedChunkDeltaRuleFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, q, k, v, beta, BT, initial_state, output_final_state, checkpoint_level=0):
         # lvl=1 will recompute ``fwd_prepare_wy_repr`` for saving memory.
         assert checkpoint_level in [0, 1]
@@ -345,7 +344,7 @@ class FusedChunkDeltaRuleFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do, d_final_state=None):
         q, k_origin, v, v_new, v_new2, d, beta, initial_state = ctx.saved_tensors
         chunk_size = ctx.chunk_size

--- a/fla/ops/delta_rule/wy_fast.py
+++ b/fla/ops/delta_rule/wy_fast.py
@@ -4,9 +4,8 @@ import torch
 import triton
 import triton.language as tl
 from einops import rearrange
-from torch.cuda.amp import custom_bwd, custom_fwd
 
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 
 # Inspired by "THE WY REPRESENTATION FOR PRODUCTS OF HOUSEHOLDER MATRICES" https://epubs.siam.org/doi/pdf/10.1137/0908009
@@ -288,7 +287,7 @@ class WYRepresentationPrepration(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, k, v, beta, chunk_size=64):
         ctx.BT = chunk_size
         w, u, A = fwd_prepare_wy_repr(k, v, beta, ctx.BT)
@@ -297,7 +296,7 @@ class WYRepresentationPrepration(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, dw, du):
         k, v, beta, A = ctx.saved_tensors
         BT = ctx.BT

--- a/fla/ops/linear_attn/chunk.py
+++ b/fla/ops/linear_attn/chunk.py
@@ -6,10 +6,9 @@ from typing import Optional, Tuple
 import torch
 import triton
 import triton.language as tl
-from torch.cuda.amp import custom_bwd, custom_fwd
 
 from fla.ops.linear_attn.utils import normalize_output
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 
 @triton.jit
@@ -238,7 +237,7 @@ class ChunkLinearAttentionFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, q, k, v, scale, initial_state, output_final_state):
         B, H, T, K, V = *q.shape, v.shape[-1]
         BT = 64
@@ -282,7 +281,7 @@ class ChunkLinearAttentionFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do, dht=None):
         q, k, v, h = ctx.saved_tensors
 

--- a/fla/ops/rebased/parallel.py
+++ b/fla/ops/rebased/parallel.py
@@ -4,9 +4,8 @@
 import torch
 import triton
 import triton.language as tl
-from torch.cuda.amp import custom_bwd, custom_fwd
 
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 # Rebased: Linear Transformers with Learnable Kernel Functions are Better In-Context Models
 # https://github.com/corl-team/rebased/blob/main/flash_linear_attention/fla/ops/triton/rebased_fast/parallel.py
@@ -339,7 +338,7 @@ class ParallelBasedFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, q, k, v, scale):
         BTL, BTS = 128, 32
         assert BTL % BTS == 0
@@ -374,7 +373,7 @@ class ParallelBasedFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do, dz):
         q, k, v = ctx.saved_tensors
         scale = ctx.scale

--- a/fla/ops/retention/chunk.py
+++ b/fla/ops/retention/chunk.py
@@ -6,9 +6,8 @@ from typing import Tuple
 import torch
 import triton
 import triton.language as tl
-from torch.cuda.amp import custom_bwd, custom_fwd
 
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 
 @triton.autotune(
@@ -375,7 +374,7 @@ class ChunkRetentionFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, q, k, v, initial_state, output_final_state, scale, checkpoint_level):
         BT = 64
         h, final_state = chunk_fwd_h_fn(k, v, BT, initial_state, output_final_state)
@@ -388,7 +387,7 @@ class ChunkRetentionFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do, d_ht=None):
         BT, scale = ctx.BT, ctx.scale
         q, k, v, h, initial_state = ctx.saved_tensors

--- a/fla/ops/retention/chunk_fuse.py
+++ b/fla/ops/retention/chunk_fuse.py
@@ -7,9 +7,8 @@ import torch
 import triton
 import triton.language as tl
 from packaging import version
-from torch.cuda.amp import custom_bwd, custom_fwd
 
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 # on-the-fly computation without materializing hidden statets into HBMs
 
@@ -231,7 +230,7 @@ class FusedChunkRetentionFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, q, k, v, initial_state, output_final_state):
         B, H, T, K, V = *k.shape, v.shape[-1]
 
@@ -283,7 +282,7 @@ class FusedChunkRetentionFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do, dht=None):
         q, k, v, initial_state = ctx.saved_tensors
         B, H, T, K, V = *k.shape, v.shape[-1]

--- a/fla/ops/retention/parallel.py
+++ b/fla/ops/retention/parallel.py
@@ -4,9 +4,8 @@
 import torch
 import triton
 import triton.language as tl
-from torch.cuda.amp import custom_bwd, custom_fwd
 
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 
 @triton.jit
@@ -290,7 +289,7 @@ class ParallelRetentionFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, q, k, v):
         BTL, BTS = 128, 32
         assert BTL % BTS == 0
@@ -319,7 +318,7 @@ class ParallelRetentionFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do):
         q, k, v = ctx.saved_tensors
         BTL, BTS = 64, 32

--- a/fla/ops/rwkv6/recurrent_fuse.py
+++ b/fla/ops/rwkv6/recurrent_fuse.py
@@ -7,10 +7,9 @@ from typing import Tuple
 import torch
 import triton
 import triton.language as tl
-from torch.cuda.amp import custom_bwd, custom_fwd
 
 from fla.ops.utils import chunk_global_reversed_cumsum
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 
 @triton.jit
@@ -239,7 +238,7 @@ class FusedRecurrentRWKV6Function(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, r, k, v, w, u, scale=None, initial_state=None, output_final_state=False, reverse=False):
         q = r
         B, H, T, K, V = *q.shape, v.shape[-1]
@@ -274,7 +273,7 @@ class FusedRecurrentRWKV6Function(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do, dht=None):
         q, k, v, w, u, initial_state = ctx.saved_tensors
         B, H, T, K, V = *q.shape, v.shape[-1]

--- a/fla/ops/simple_gla/chunk.py
+++ b/fla/ops/simple_gla/chunk.py
@@ -6,9 +6,8 @@ from typing import Optional, Tuple
 import torch
 import triton
 import triton.language as tl
-from torch.cuda.amp import custom_bwd, custom_fwd
 
-from fla.utils import contiguous
+from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 
 
 @triton.jit
@@ -259,7 +258,7 @@ class SimpleGLAFunction(torch.autograd.Function):
 
     @staticmethod
     @contiguous
-    @custom_fwd
+    @autocast_custom_fwd
     def forward(ctx, q, k, v, g, scale, initial_state, output_final_state):
         B, H, T, K, V = *q.shape, v.shape[-1]
         BT = 64
@@ -309,7 +308,7 @@ class SimpleGLAFunction(torch.autograd.Function):
     
     @staticmethod
     @contiguous
-    @custom_bwd
+    @autocast_custom_bwd
     def backward(ctx, do, dht=None):
         q, k, v, h, g = ctx.saved_tensors
 

--- a/fla/utils.py
+++ b/fla/utils.py
@@ -3,6 +3,7 @@
 import functools
 
 import torch
+from packaging import version
 
 
 def contiguous(fn):
@@ -31,3 +32,11 @@ def checkpoint(func):
     def wrapper(*args, **kwargs):
         return torch.utils.checkpoint.checkpoint(func, *args, **kwargs)
     return wrapper
+
+
+if version.parse(torch.__version__) >= version.parse("2.4"):
+    autocast_custom_fwd = functools.partial(torch.amp.custom_fwd, device_type="cuda")
+    autocast_custom_bwd = functools.partial(torch.amp.custom_bwd, device_type="cuda")
+else:
+    autocast_custom_fwd = torch.cuda.amp.custom_fwd
+    autocast_custom_bwd = torch.cuda.amp.custom_bwd


### PR DESCRIPTION
In torch 2.4.0 the autocast APIs were unified under torch.amp. Usage of torch.{device}.amp will produce a deprecation warning: FutureWarning: `torch.cuda.amp.custom_fwd(args...)` is deprecated. Please use `torch.amp.custom_fwd(args..., device_type='cuda')` instead.

This PR gates `custom_fwd/custom_bwd` by version, so that < 2.4 torch is still usable. Since these ops are used for a lot of primitives I've moved them to `fla.utils` and renamed them for clarity. This should still allow future support for device types other than cuda.