### PR TITLE
[`Mamba2`] Post Merge Fixes - `norm_before_gate` and generation with `inputs_embeds` 

### DIFF
--- a/fla/models/mamba2/configuration_mamba2.py
+++ b/fla/models/mamba2/configuration_mamba2.py
@@ -80,8 +80,6 @@ class Mamba2Config(PretrainedConfig):
             Whether or not to rescale `out_proj` weights when initializing.
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the cache should be used.
-        norm_before_gate (`bool`, *optional*, defaults to `True`):
-            Option of cuda kernels -whether to normalize before the gate or not.
         rms_norm (`bool`, *optional*, defaults to `True`):
             Whether to use RMS norm or not.
         chunk_size (`int`, *optional*, defaults to 256):
@@ -119,7 +117,6 @@ class Mamba2Config(PretrainedConfig):
         time_step_limit=(0.0, float("inf")),
         rescale_prenorm_residual: bool = False,
         use_cache: bool = True,
-        norm_before_gate: bool = True,
         rms_norm: bool = True,
         chunk_size: int = 256,
         fuse_cross_entropy: bool = True,
@@ -155,7 +152,6 @@ class Mamba2Config(PretrainedConfig):
         self.n_groups = n_groups
         self.num_heads = num_heads
         self.head_dim = head_dim
-        self.norm_before_gate = norm_before_gate
         self.rms_norm = rms_norm
         self.state_size = state_size
         self.chunk_size = chunk_size

--- a/fla/models/mamba2/modeling_mamba2.py
+++ b/fla/models/mamba2/modeling_mamba2.py
@@ -195,7 +195,6 @@ class Mamba2Mixer(nn.Module):
         self.activation = config.hidden_act
         self.act = ACT2FN[config.hidden_act]
 
-        self.norm_before_gate = config.norm_before_gate
         self.layer_norm_epsilon = config.layer_norm_epsilon
         self.rms_norm = config.rms_norm
 
@@ -352,7 +351,7 @@ class Mamba2Mixer(nn.Module):
                     outproj_bias=self.out_proj.bias,
                     headdim=self.head_dim,
                     ngroups=self.n_groups,
-                    norm_before_gate=self.norm_before_gate,
+                    norm_before_gate=False,
                     return_final_states=True,
                     **dt_limit_kwargs,
                 )
@@ -960,8 +959,8 @@ class Mamba2ForCausalLM(Mamba2PreTrainedModel):
         attention_mask: Optional[torch.Tensor] = None,
         **kwargs,
     ):
-        if input_ids.shape[1] == 0:
-            past_len = inputs_embeds.shape[1]
+        if inputs_embeds is not None:
+            past_len = inputs_embeds.shape[1] + input_ids.shape[1]
         else:
             past_len = input_ids.shape[1]
         if use_cache:


### PR DESCRIPTION
Since the implementation seems like a mirror to the one of the transformers repo, I thought I'd share some fixes post-merge that have been applied:
1. Generation when passing `inputs_embeds` has been broken, ref. https://github.com/huggingface/transformers/pull/32694
2. Incorrect usage of the `norm_before_gate` flag which causes misaligned training when using the completely fused kernel, ref. https://github.com/huggingface/transformers/pull/32686

Cool repo btw :)