### PR TITLE
Add fine-grained warning category for easier supression

### DIFF
--- a/fla/layers/attn.py
+++ b/fla/layers/attn.py
@@ -21,7 +21,8 @@ try:
     from flash_attn.bert_padding import (index_first_axis, pad_input,
                                          unpad_input)
 except ImportError:
-    warnings.warn("Flash Attention is not installed. Please install it via `pip install flash-attn --no-build-isolation`")
+    warnings.warn("Flash Attention is not installed. Please install it via `pip install flash-attn --no-build-isolation`", 
+                  category=ImportWarning)
     flash_attn_func = None
 
 logger = logging.get_logger(__name__)

--- a/fla/modules/convolution.py
+++ b/fla/modules/convolution.py
@@ -113,7 +113,8 @@ class ShortConvolution(nn.Conv1d):
             else:
                 warnings.warn(
                     "The naive Pytorch verison is very slow in practice, "
-                    "please run `pip install causal-conv1d>=1.4.0` to install fast causal short convolution CUDA kernel"
+                    "please run `pip install causal-conv1d>=1.4.0` to install fast causal short convolution CUDA kernel",
+                    category=ImportWarning
                 )
         self.use_fast_conv1d = use_fast_conv1d
 


### PR DESCRIPTION
Some packages like flash-attn (and causal-conv) are used only for specific primitives, however due to the import strategy in `fla.__init__.py` a user without flash-attn installed will see a warning when using other modules. I've added a category to the warnings emitted in these cases so one can more safely ignore it when importing other layers, i.e. one can use:

```py
import warnings
with warnings.catch_warnings(action="ignore", category=ImportWarning):
    from fla.ops.gla import chunk_gla
    from fla.ops.linear_attn import chunk_linear_attn
```